### PR TITLE
Update version to 0.5.2 and add release notes

### DIFF
--- a/src/CommonIFileTests.cs
+++ b/src/CommonIFileTests.cs
@@ -88,7 +88,17 @@ namespace OwlCore.Storage.CommonTests
 
             cancellationTokenSource.Cancel();
 
-            await Assert.ThrowsExceptionAsync<OperationCanceledException>(() => file.OpenStreamAsync(accessMode, cancellationTokenSource.Token));
+            await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
+            {
+                try
+                {
+                    await file.OpenStreamAsync(accessMode, cancellationTokenSource.Token);
+                }
+                catch (TaskCanceledException e)
+                {
+                    throw new OperationCanceledException(e.Message);
+                }
+            });
         }
     }
 

--- a/src/OwlCore.Storage.CommonTests.csproj
+++ b/src/OwlCore.Storage.CommonTests.csproj
@@ -14,13 +14,17 @@
 		<AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
 		<Author>Arlo Godfrey</Author>
-		<Version>0.5.1</Version>
+		<Version>0.5.2</Version>
 		<Product>OwlCore</Product>
 		<Description></Description>
 		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
 		<PackageIcon>logo.png</PackageIcon>
 		<PackageProjectUrl>https://github.com/Arlodotexe/OwlCore.Storage.CommonTests</PackageProjectUrl>
 		<PackageReleaseNotes>
+--- 0.5.2 ---
+[Fix]
+Fixed an issue where cancellation tokens were not properly handled in CommonIFileTests.
+
 --- 0.5.1 ---
 [Improvements]
 Added detailed error messages for why CommonIModifiableFolder tests fail and where to check your code for issues.


### PR DESCRIPTION
Updates the version number and release notes in `src/OwlCore.Storage.CommonTests.csproj`.

- **Version Update**: Changes the `<Version>` tag from `0.5.1` to `0.5.2`.
- **Release Notes Addition**: Adds a new entry under `<PackageReleaseNotes>` for version `0.5.2`, detailing a fix related to cancellation tokens not being properly handled in `CommonIFileTests`.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Arlodotexe/OwlCore.Storage.CommonTests/pull/3?shareId=d1047fa4-9672-4d5b-b503-dd2c2c065fac).