### PR TITLE
Update version to 0.5.2 and add release notes

### DIFF
--- a/src/OwlCore.Storage.CommonTests.csproj
+++ b/src/OwlCore.Storage.CommonTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<Nullable>enable</Nullable>
@@ -14,13 +14,17 @@
 		<AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
 		<Author>Arlo Godfrey</Author>
-		<Version>0.5.1</Version>
+		<Version>0.5.2</Version>
 		<Product>OwlCore</Product>
 		<Description></Description>
 		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
 		<PackageIcon>logo.png</PackageIcon>
 		<PackageProjectUrl>https://github.com/Arlodotexe/OwlCore.Storage.CommonTests</PackageProjectUrl>
 		<PackageReleaseNotes>
+--- 0.5.2 ---
+[Fix]
+Fixed an issue where Assert.ThrowsException explicitly checks for an OperationCanceledException, not the exceptions that derive from it. Some libraries throw a TaskCanceledException instead of an OperationCanceledException, which may cause issues with tests.
+
 --- 0.5.1 ---
 [Improvements]
 Added detailed error messages for why CommonIModifiableFolder tests fail and where to check your code for issues.


### PR DESCRIPTION
Updates the version number and release notes in `src/OwlCore.Storage.CommonTests.csproj`.

- **Version Update**: Changes the `<Version>` tag from `0.5.1` to `0.5.2`.
- **Release Notes Addition**: Adds a new entry under `<PackageReleaseNotes>` for version `0.5.2`.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Arlodotexe/OwlCore.Storage.CommonTests/pull/3?shareId=06337eb3-9a4b-42ca-a0df-65eeb3108fab).